### PR TITLE
fix: remove `?` from plugin name in docs

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -1,5 +1,5 @@
 ---
-name: Is It Up Yet?
+name: Is It Up Yet
 description: Plugin to check for a service to start listening on a specified host and port.
 
 author: dvjn


### PR DESCRIPTION
The name attribute in docs is used by woodpecker docs as the slug for the plugin documentation. This means a slug with `?` is generated for the plugin, but the `?` is interpreted as the start of query params in the URL and not part of slug, which means the plugin page is not accessible.